### PR TITLE
Add CoreData models for VIP VoterInfo Query

### DIFF
--- a/objc/VotingInformationProject/VIPModel.xcdatamodeld/VIPModel.xcdatamodel/contents
+++ b/objc/VotingInformationProject/VIPModel.xcdatamodeld/VIPModel.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="3401" systemVersion="13B42" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <elements/>
+</model>

--- a/objc/VotingInformationProject/VotingInformationProject.xcodeproj/project.pbxproj
+++ b/objc/VotingInformationProject/VotingInformationProject.xcodeproj/project.pbxproj
@@ -11,6 +11,15 @@
 		4903245D1890650A00FD9828 /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4903245B1890650A00FD9828 /* AddressBook.framework */; };
 		4903245E1890650A00FD9828 /* AddressBookUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4903245C1890650A00FD9828 /* AddressBookUI.framework */; };
 		49196B8D189AED8D007DCBD9 /* VIPStoryBoard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49196B8F189AED8D007DCBD9 /* VIPStoryBoard.storyboard */; };
+		491BEA21189C0C0C00FCB21D /* Candidate.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA20189C0C0C00FCB21D /* Candidate.m */; };
+		491BEA24189C0C0D00FCB21D /* Election.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA23189C0C0D00FCB21D /* Election.m */; };
+		491BEA27189C0C0D00FCB21D /* Contest.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA26189C0C0D00FCB21D /* Contest.m */; };
+		491BEA2A189C0C0D00FCB21D /* ElectionOfficial.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA29189C0C0D00FCB21D /* ElectionOfficial.m */; };
+		491BEA2D189C0C0D00FCB21D /* State.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA2C189C0C0D00FCB21D /* State.m */; };
+		491BEA30189C0C0D00FCB21D /* PollingLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA2F189C0C0D00FCB21D /* PollingLocation.m */; };
+		491BEA33189C0C0D00FCB21D /* District.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA32189C0C0D00FCB21D /* District.m */; };
+		491BEA36189C0C0E00FCB21D /* ElectionAdministrationBody.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA35189C0C0E00FCB21D /* ElectionAdministrationBody.m */; };
+		491BEA39189C0C0E00FCB21D /* DataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 491BEA38189C0C0E00FCB21D /* DataSource.m */; };
 		491EE5AF188EE0600018A060 /* settings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 491EE5AE188EE0600018A060 /* settings.plist */; };
 		49273490188DE80000B25554 /* elections.json in Resources */ = {isa = PBXBuildFile; fileRef = 4927348F188DE80000B25554 /* elections.json */; };
 		494133FD188F0BD3006F7D0F /* ElectionModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 494133FC188F0BD3006F7D0F /* ElectionModelTests.m */; };
@@ -55,11 +64,29 @@
 		2D641A22ED5044C8BE72A960 /* Pods-VotingInformationProjectTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VotingInformationProjectTests.xcconfig"; path = "Pods/Pods-VotingInformationProjectTests.xcconfig"; sourceTree = "<group>"; };
 		4903245B1890650A00FD9828 /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		4903245C1890650A00FD9828 /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
-		49196B90189AED9D007DCBD9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file; name = Base; path = Base.lproj/VIPStoryBoard.storyboard; sourceTree = "<group>"; };
+		49196B90189AED9D007DCBD9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/VIPStoryBoard.storyboard; sourceTree = "<group>"; };
 		49196B93189AEE33007DCBD9 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/VIPStoryBoard.strings; sourceTree = "<group>"; };
 		49196B94189AEE33007DCBD9 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		49196B95189AEE33007DCBD9 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		49196B96189AEE33007DCBD9 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		491BEA1F189C0C0C00FCB21D /* Candidate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Candidate.h; path = CoreDataModels/Candidate.h; sourceTree = "<group>"; };
+		491BEA20189C0C0C00FCB21D /* Candidate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Candidate.m; path = CoreDataModels/Candidate.m; sourceTree = "<group>"; };
+		491BEA22189C0C0D00FCB21D /* Election.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Election.h; path = CoreDataModels/Election.h; sourceTree = "<group>"; };
+		491BEA23189C0C0D00FCB21D /* Election.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Election.m; path = CoreDataModels/Election.m; sourceTree = "<group>"; };
+		491BEA25189C0C0D00FCB21D /* Contest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Contest.h; path = CoreDataModels/Contest.h; sourceTree = "<group>"; };
+		491BEA26189C0C0D00FCB21D /* Contest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Contest.m; path = CoreDataModels/Contest.m; sourceTree = "<group>"; };
+		491BEA28189C0C0D00FCB21D /* ElectionOfficial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ElectionOfficial.h; path = CoreDataModels/ElectionOfficial.h; sourceTree = "<group>"; };
+		491BEA29189C0C0D00FCB21D /* ElectionOfficial.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ElectionOfficial.m; path = CoreDataModels/ElectionOfficial.m; sourceTree = "<group>"; };
+		491BEA2B189C0C0D00FCB21D /* State.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = State.h; path = CoreDataModels/State.h; sourceTree = "<group>"; };
+		491BEA2C189C0C0D00FCB21D /* State.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = State.m; path = CoreDataModels/State.m; sourceTree = "<group>"; };
+		491BEA2E189C0C0D00FCB21D /* PollingLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PollingLocation.h; path = CoreDataModels/PollingLocation.h; sourceTree = "<group>"; };
+		491BEA2F189C0C0D00FCB21D /* PollingLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PollingLocation.m; path = CoreDataModels/PollingLocation.m; sourceTree = "<group>"; };
+		491BEA31189C0C0D00FCB21D /* District.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = District.h; path = CoreDataModels/District.h; sourceTree = "<group>"; };
+		491BEA32189C0C0D00FCB21D /* District.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = District.m; path = CoreDataModels/District.m; sourceTree = "<group>"; };
+		491BEA34189C0C0E00FCB21D /* ElectionAdministrationBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ElectionAdministrationBody.h; path = CoreDataModels/ElectionAdministrationBody.h; sourceTree = "<group>"; };
+		491BEA35189C0C0E00FCB21D /* ElectionAdministrationBody.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ElectionAdministrationBody.m; path = CoreDataModels/ElectionAdministrationBody.m; sourceTree = "<group>"; };
+		491BEA37189C0C0E00FCB21D /* DataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DataSource.h; path = CoreDataModels/DataSource.h; sourceTree = "<group>"; };
+		491BEA38189C0C0E00FCB21D /* DataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DataSource.m; path = CoreDataModels/DataSource.m; sourceTree = "<group>"; };
 		491EE5AE188EE0600018A060 /* settings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = settings.plist; sourceTree = "<group>"; };
 		4927348F188DE80000B25554 /* elections.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = elections.json; sourceTree = "<group>"; };
 		494133FC188F0BD3006F7D0F /* ElectionModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ElectionModelTests.m; sourceTree = "<group>"; };
@@ -129,6 +156,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		491BEA03189C0B5F00FCB21D /* CoreDataModels */ = {
+			isa = PBXGroup;
+			children = (
+				491BEA37189C0C0E00FCB21D /* DataSource.h */,
+				491BEA38189C0C0E00FCB21D /* DataSource.m */,
+				491BEA34189C0C0E00FCB21D /* ElectionAdministrationBody.h */,
+				491BEA35189C0C0E00FCB21D /* ElectionAdministrationBody.m */,
+				491BEA31189C0C0D00FCB21D /* District.h */,
+				491BEA32189C0C0D00FCB21D /* District.m */,
+				491BEA2E189C0C0D00FCB21D /* PollingLocation.h */,
+				491BEA2F189C0C0D00FCB21D /* PollingLocation.m */,
+				491BEA2B189C0C0D00FCB21D /* State.h */,
+				491BEA2C189C0C0D00FCB21D /* State.m */,
+				491BEA28189C0C0D00FCB21D /* ElectionOfficial.h */,
+				491BEA29189C0C0D00FCB21D /* ElectionOfficial.m */,
+				491BEA25189C0C0D00FCB21D /* Contest.h */,
+				491BEA26189C0C0D00FCB21D /* Contest.m */,
+				491BEA22189C0C0D00FCB21D /* Election.h */,
+				491BEA23189C0C0D00FCB21D /* Election.m */,
+				491BEA1F189C0C0C00FCB21D /* Candidate.h */,
+				491BEA20189C0C0C00FCB21D /* Candidate.m */,
+			);
+			name = CoreDataModels;
+			sourceTree = "<group>";
+		};
 		49273491188DE8DA00B25554 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -204,6 +256,7 @@
 		53D3A78E1889A05B00920A70 /* VotingInformationProject */ = {
 			isa = PBXGroup;
 			children = (
+				491BEA03189C0B5F00FCB21D /* CoreDataModels */,
 				49E981411892F7F700E26C5D /* Controllers */,
 				49E9814B1892F81600E26C5D /* Models */,
 				53D3A7971889A05B00920A70 /* AppDelegate.h */,
@@ -417,14 +470,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				491BEA36189C0C0E00FCB21D /* ElectionAdministrationBody.m in Sources */,
+				491BEA2D189C0C0D00FCB21D /* State.m in Sources */,
 				53D3A7991889A05B00920A70 /* AppDelegate.m in Sources */,
 				49E981481892F7F700E26C5D /* ContactsSearchViewController.m in Sources */,
 				53D3A79C1889A05B00920A70 /* VotingInformationProject.xcdatamodeld in Sources */,
+				491BEA24189C0C0D00FCB21D /* Election.m in Sources */,
+				491BEA21189C0C0C00FCB21D /* Candidate.m in Sources */,
+				491BEA39189C0C0E00FCB21D /* DataSource.m in Sources */,
 				49E9814A1892F7F700E26C5D /* NearbyPollingViewController.m in Sources */,
 				53D3A7951889A05B00920A70 /* main.m in Sources */,
 				49E981531892F81600E26C5D /* FindElectionsCell.m in Sources */,
+				491BEA33189C0C0D00FCB21D /* District.m in Sources */,
+				491BEA2A189C0C0D00FCB21D /* ElectionOfficial.m in Sources */,
+				491BEA30189C0C0D00FCB21D /* PollingLocation.m in Sources */,
 				49E981521892F81600E26C5D /* Election.m in Sources */,
 				49E981491892F7F700E26C5D /* FindElectionsViewController.m in Sources */,
+				491BEA27189C0C0D00FCB21D /* Contest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/objc/VotingInformationProject/VotingInformationProject.xcworkspace/contents.xcworkspacedata
+++ b/objc/VotingInformationProject/VotingInformationProject.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:VIPModel.xcdatamodeld">
+   </FileRef>
+   <FileRef
       location = "group:VotingInformationProject.xcodeproj">
    </FileRef>
    <FileRef

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Candidate.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Candidate.h
@@ -1,0 +1,26 @@
+//
+//  Candidate.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Contest;
+
+@interface Candidate : NSManagedObject
+
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSString * party;
+@property (nonatomic, retain) NSString * candidateURL;
+@property (nonatomic, retain) NSString * phone;
+@property (nonatomic, retain) NSString * photoURL;
+@property (nonatomic, retain) NSString * email;
+@property (nonatomic, retain) NSNumber * orderOnBallot;
+@property (nonatomic, retain) NSData * photo;
+@property (nonatomic, retain) Contest *contest;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Candidate.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Candidate.m
@@ -1,0 +1,25 @@
+//
+//  Candidate.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "Candidate.h"
+#import "Contest.h"
+
+
+@implementation Candidate
+
+@dynamic name;
+@dynamic party;
+@dynamic candidateURL;
+@dynamic phone;
+@dynamic photoURL;
+@dynamic email;
+@dynamic orderOnBallot;
+@dynamic photo;
+@dynamic contest;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Contest.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Contest.h
@@ -1,0 +1,47 @@
+//
+//  Contest.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Candidate, DataSource, District, Election;
+
+@interface Contest : NSManagedObject
+
+@property (nonatomic, retain) NSString * contestId;
+@property (nonatomic, retain) NSString * type;
+@property (nonatomic, retain) NSString * primaryParty;
+@property (nonatomic, retain) NSString * electorateSpecifications;
+@property (nonatomic, retain) NSString * special;
+@property (nonatomic, retain) NSString * office;
+@property (nonatomic, retain) NSString * level;
+@property (nonatomic, retain) NSNumber * numberElected;
+@property (nonatomic, retain) NSNumber * numberVotingFor;
+@property (nonatomic, retain) NSNumber * ballotPlacement;
+@property (nonatomic, retain) NSString * referendumTitle;
+@property (nonatomic, retain) NSString * referendumSubtitle;
+@property (nonatomic, retain) NSString * referendumURL;
+@property (nonatomic, retain) NSSet *dataSource;
+@property (nonatomic, retain) District *district;
+@property (nonatomic, retain) NSSet *candidates;
+@property (nonatomic, retain) Election *election;
+@end
+
+@interface Contest (CoreDataGeneratedAccessors)
+
+- (void)addDataSourceObject:(DataSource *)value;
+- (void)removeDataSourceObject:(DataSource *)value;
+- (void)addDataSource:(NSSet *)values;
+- (void)removeDataSource:(NSSet *)values;
+
+- (void)addCandidatesObject:(Candidate *)value;
+- (void)removeCandidatesObject:(Candidate *)value;
+- (void)addCandidates:(NSSet *)values;
+- (void)removeCandidates:(NSSet *)values;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Contest.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Contest.m
@@ -1,0 +1,36 @@
+//
+//  Contest.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "Contest.h"
+#import "Candidate.h"
+#import "DataSource.h"
+#import "District.h"
+#import "Election.h"
+
+
+@implementation Contest
+
+@dynamic contestId;
+@dynamic type;
+@dynamic primaryParty;
+@dynamic electorateSpecifications;
+@dynamic special;
+@dynamic office;
+@dynamic level;
+@dynamic numberElected;
+@dynamic numberVotingFor;
+@dynamic ballotPlacement;
+@dynamic referendumTitle;
+@dynamic referendumSubtitle;
+@dynamic referendumURL;
+@dynamic dataSource;
+@dynamic district;
+@dynamic candidates;
+@dynamic election;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/DataSource.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/DataSource.h
@@ -1,0 +1,23 @@
+//
+//  DataSource.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Contest, Election, PollingLocation, State;
+
+@interface DataSource : NSManagedObject
+
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSNumber * isOfficial;
+@property (nonatomic, retain) Election *election;
+@property (nonatomic, retain) PollingLocation *pollingLocation;
+@property (nonatomic, retain) Contest *contest;
+@property (nonatomic, retain) State *state;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/DataSource.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/DataSource.m
@@ -1,0 +1,25 @@
+//
+//  DataSource.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "DataSource.h"
+#import "Contest.h"
+#import "Election.h"
+#import "PollingLocation.h"
+#import "State.h"
+
+
+@implementation DataSource
+
+@dynamic name;
+@dynamic isOfficial;
+@dynamic election;
+@dynamic pollingLocation;
+@dynamic contest;
+@dynamic state;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/District.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/District.h
@@ -1,0 +1,29 @@
+//
+//  District.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Contest;
+
+@interface District : NSManagedObject
+
+@property (nonatomic, retain) NSString * districtId;
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSString * scope;
+@property (nonatomic, retain) NSSet *contests;
+@end
+
+@interface District (CoreDataGeneratedAccessors)
+
+- (void)addContestsObject:(Contest *)value;
+- (void)removeContestsObject:(Contest *)value;
+- (void)addContests:(NSSet *)values;
+- (void)removeContests:(NSSet *)values;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/District.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/District.m
@@ -1,0 +1,20 @@
+//
+//  District.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "District.h"
+#import "Contest.h"
+
+
+@implementation District
+
+@dynamic districtId;
+@dynamic name;
+@dynamic scope;
+@dynamic contests;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Election.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Election.h
@@ -1,0 +1,51 @@
+//
+//  Election.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Contest, DataSource, PollingLocation, State;
+
+@interface Election : NSManagedObject
+
+@property (nonatomic, retain) NSString * electionId;
+@property (nonatomic, retain) NSString * electionName;
+@property (nonatomic, retain) NSDate * date;
+@property (nonatomic, retain) NSString * locationName;
+@property (nonatomic, retain) NSString * address;
+@property (nonatomic, retain) NSNumber * addressLat;
+@property (nonatomic, retain) NSNumber * addressLon;
+@property (nonatomic, retain) NSSet *dataSource;
+@property (nonatomic, retain) NSSet *states;
+@property (nonatomic, retain) NSSet *pollingLocations;
+@property (nonatomic, retain) NSSet *contests;
+@end
+
+@interface Election (CoreDataGeneratedAccessors)
+
+- (void)addDataSourceObject:(DataSource *)value;
+- (void)removeDataSourceObject:(DataSource *)value;
+- (void)addDataSource:(NSSet *)values;
+- (void)removeDataSource:(NSSet *)values;
+
+- (void)addStatesObject:(State *)value;
+- (void)removeStatesObject:(State *)value;
+- (void)addStates:(NSSet *)values;
+- (void)removeStates:(NSSet *)values;
+
+- (void)addPollingLocationsObject:(PollingLocation *)value;
+- (void)removePollingLocationsObject:(PollingLocation *)value;
+- (void)addPollingLocations:(NSSet *)values;
+- (void)removePollingLocations:(NSSet *)values;
+
+- (void)addContestsObject:(Contest *)value;
+- (void)removeContestsObject:(Contest *)value;
+- (void)addContests:(NSSet *)values;
+- (void)removeContests:(NSSet *)values;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Election.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Election.m
@@ -1,0 +1,30 @@
+//
+//  Election.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "Election.h"
+#import "Contest.h"
+#import "DataSource.h"
+#import "PollingLocation.h"
+#import "State.h"
+
+
+@implementation Election
+
+@dynamic electionId;
+@dynamic electionName;
+@dynamic date;
+@dynamic locationName;
+@dynamic address;
+@dynamic addressLat;
+@dynamic addressLon;
+@dynamic dataSource;
+@dynamic states;
+@dynamic pollingLocations;
+@dynamic contests;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionAdministrationBody.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionAdministrationBody.h
@@ -1,0 +1,39 @@
+//
+//  ElectionAdministrationBody.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class ElectionOfficial, State;
+
+@interface ElectionAdministrationBody : NSManagedObject
+
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSString * electionInfoURL;
+@property (nonatomic, retain) NSString * electionRegistrationURL;
+@property (nonatomic, retain) NSString * electionRegistrationConfirmationURL;
+@property (nonatomic, retain) NSString * absenteeVotingInfoURL;
+@property (nonatomic, retain) NSString * votingLocationFinderURL;
+@property (nonatomic, retain) NSString * ballotInfoURL;
+@property (nonatomic, retain) NSString * electionRulesURL;
+@property (nonatomic, retain) NSString * voterServices;
+@property (nonatomic, retain) NSString * hoursOfOperation;
+@property (nonatomic, retain) NSString * physicalAddress;
+@property (nonatomic, retain) NSString * mailingAddress;
+@property (nonatomic, retain) State *state;
+@property (nonatomic, retain) NSSet *electionOfficials;
+@end
+
+@interface ElectionAdministrationBody (CoreDataGeneratedAccessors)
+
+- (void)addElectionOfficialsObject:(ElectionOfficial *)value;
+- (void)removeElectionOfficialsObject:(ElectionOfficial *)value;
+- (void)addElectionOfficials:(NSSet *)values;
+- (void)removeElectionOfficials:(NSSet *)values;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionAdministrationBody.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionAdministrationBody.m
@@ -1,0 +1,31 @@
+//
+//  ElectionAdministrationBody.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "ElectionAdministrationBody.h"
+#import "ElectionOfficial.h"
+#import "State.h"
+
+
+@implementation ElectionAdministrationBody
+
+@dynamic name;
+@dynamic electionInfoURL;
+@dynamic electionRegistrationURL;
+@dynamic electionRegistrationConfirmationURL;
+@dynamic absenteeVotingInfoURL;
+@dynamic votingLocationFinderURL;
+@dynamic ballotInfoURL;
+@dynamic electionRulesURL;
+@dynamic voterServices;
+@dynamic hoursOfOperation;
+@dynamic physicalAddress;
+@dynamic mailingAddress;
+@dynamic state;
+@dynamic electionOfficials;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionOfficial.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionOfficial.h
@@ -1,0 +1,23 @@
+//
+//  ElectionOfficial.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class ElectionAdministrationBody;
+
+@interface ElectionOfficial : NSManagedObject
+
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSString * title;
+@property (nonatomic, retain) NSString * officePhoneNumber;
+@property (nonatomic, retain) NSString * faxNumber;
+@property (nonatomic, retain) NSString * email;
+@property (nonatomic, retain) ElectionAdministrationBody *electionAdministrationBody;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionOfficial.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/ElectionOfficial.m
@@ -1,0 +1,22 @@
+//
+//  ElectionOfficial.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "ElectionOfficial.h"
+#import "ElectionAdministrationBody.h"
+
+
+@implementation ElectionOfficial
+
+@dynamic name;
+@dynamic title;
+@dynamic officePhoneNumber;
+@dynamic faxNumber;
+@dynamic email;
+@dynamic electionAdministrationBody;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/PollingLocation.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/PollingLocation.h
@@ -1,0 +1,38 @@
+//
+//  PollingLocation.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class DataSource, Election;
+
+@interface PollingLocation : NSManagedObject
+
+@property (nonatomic, retain) NSString * pollingLocationId;
+@property (nonatomic, retain) NSString * address;
+@property (nonatomic, retain) NSNumber * addressLat;
+@property (nonatomic, retain) NSNumber * addressLon;
+@property (nonatomic, retain) NSString * notes;
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSDate * startDate;
+@property (nonatomic, retain) NSDate * endDate;
+@property (nonatomic, retain) NSString * pollingHours;
+@property (nonatomic, retain) NSNumber * isEarlyVoteSite;
+@property (nonatomic, retain) NSString * voterServices;
+@property (nonatomic, retain) NSSet *dataSource;
+@property (nonatomic, retain) Election *election;
+@end
+
+@interface PollingLocation (CoreDataGeneratedAccessors)
+
+- (void)addDataSourceObject:(DataSource *)value;
+- (void)removeDataSourceObject:(DataSource *)value;
+- (void)addDataSource:(NSSet *)values;
+- (void)removeDataSource:(NSSet *)values;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/PollingLocation.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/PollingLocation.m
@@ -1,0 +1,30 @@
+//
+//  PollingLocation.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "PollingLocation.h"
+#import "DataSource.h"
+#import "Election.h"
+
+
+@implementation PollingLocation
+
+@dynamic pollingLocationId;
+@dynamic address;
+@dynamic addressLat;
+@dynamic addressLon;
+@dynamic notes;
+@dynamic name;
+@dynamic startDate;
+@dynamic endDate;
+@dynamic pollingHours;
+@dynamic isEarlyVoteSite;
+@dynamic voterServices;
+@dynamic dataSource;
+@dynamic election;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/State.h
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/State.h
@@ -1,0 +1,31 @@
+//
+//  State.h
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class DataSource, Election, ElectionAdministrationBody;
+
+@interface State : NSManagedObject
+
+@property (nonatomic, retain) NSString * stateId;
+@property (nonatomic, retain) NSString * name;
+@property (nonatomic, retain) NSString * localJurisdiction;
+@property (nonatomic, retain) Election *election;
+@property (nonatomic, retain) ElectionAdministrationBody *electionAdministrationBody;
+@property (nonatomic, retain) NSSet *dataSource;
+@end
+
+@interface State (CoreDataGeneratedAccessors)
+
+- (void)addDataSourceObject:(DataSource *)value;
+- (void)removeDataSourceObject:(DataSource *)value;
+- (void)addDataSource:(NSSet *)values;
+- (void)removeDataSource:(NSSet *)values;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/State.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/State.m
@@ -1,0 +1,24 @@
+//
+//  State.m
+//  VotingInformationProject
+//
+//  Created by Andrew Fink on 1/31/14.
+//  Copyright (c) 2014 Bennet Huber. All rights reserved.
+//
+
+#import "State.h"
+#import "DataSource.h"
+#import "Election.h"
+#import "ElectionAdministrationBody.h"
+
+
+@implementation State
+
+@dynamic stateId;
+@dynamic name;
+@dynamic localJurisdiction;
+@dynamic election;
+@dynamic electionAdministrationBody;
+@dynamic dataSource;
+
+@end

--- a/objc/VotingInformationProject/VotingInformationProject/VotingInformationProject.xcdatamodeld/VotingInformationProject.xcdatamodel/contents
+++ b/objc/VotingInformationProject/VotingInformationProject/VotingInformationProject.xcdatamodeld/VotingInformationProject.xcdatamodel/contents
@@ -1,4 +1,118 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model name="Test1.xcdatamodel" userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
-    <elements/>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="3401" systemVersion="13B42" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="Candidate" representedClassName="Candidate" syncable="YES">
+        <attribute name="candidateURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="orderOnBallot" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="party" optional="YES" attributeType="String" maxValueString="32" syncable="YES"/>
+        <attribute name="phone" optional="YES" attributeType="String" maxValueString="16" syncable="YES"/>
+        <attribute name="photo" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="photoURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <relationship name="contest" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Contest" inverseName="candidates" inverseEntity="Contest" syncable="YES"/>
+    </entity>
+    <entity name="Contest" representedClassName="Contest" syncable="YES">
+        <attribute name="ballotPlacement" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="contestId" attributeType="String" maxValueString="32" syncable="YES"/>
+        <attribute name="electorateSpecifications" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="level" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="numberElected" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="numberVotingFor" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="office" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="primaryParty" optional="YES" attributeType="String" maxValueString="32" syncable="YES"/>
+        <attribute name="referendumSubtitle" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="referendumTitle" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="referendumURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="special" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <relationship name="candidates" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Candidate" inverseName="contest" inverseEntity="Candidate" syncable="YES"/>
+        <relationship name="dataSource" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DataSource" inverseName="contest" inverseEntity="DataSource" syncable="YES"/>
+        <relationship name="district" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="District" inverseName="contests" inverseEntity="District" syncable="YES"/>
+        <relationship name="election" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Election" inverseName="contests" inverseEntity="Election" syncable="YES"/>
+    </entity>
+    <entity name="DataSource" representedClassName="DataSource" syncable="YES">
+        <attribute name="isOfficial" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="name" attributeType="String" maxValueString="100" syncable="YES"/>
+        <relationship name="contest" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Contest" inverseName="dataSource" inverseEntity="Contest" syncable="YES"/>
+        <relationship name="election" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Election" inverseName="dataSource" inverseEntity="Election" syncable="YES"/>
+        <relationship name="pollingLocation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PollingLocation" inverseName="dataSource" inverseEntity="PollingLocation" syncable="YES"/>
+        <relationship name="state" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="State" inverseName="dataSource" inverseEntity="State" syncable="YES"/>
+    </entity>
+    <entity name="District" representedClassName="District" syncable="YES">
+        <attribute name="districtId" attributeType="String" maxValueString="32" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="scope" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <relationship name="contests" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Contest" inverseName="district" inverseEntity="Contest" syncable="YES"/>
+    </entity>
+    <entity name="Election" representedClassName="Election" syncable="YES">
+        <attribute name="address" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="addressLat" optional="YES" attributeType="Double" defaultValueString="0" syncable="YES"/>
+        <attribute name="addressLon" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="date" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="electionId" attributeType="String" maxValueString="32" syncable="YES"/>
+        <attribute name="electionName" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="locationName" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <relationship name="contests" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Contest" inverseName="election" inverseEntity="Contest" syncable="YES"/>
+        <relationship name="dataSource" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DataSource" inverseName="election" inverseEntity="DataSource" syncable="YES"/>
+        <relationship name="pollingLocations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PollingLocation" inverseName="election" inverseEntity="PollingLocation" syncable="YES"/>
+        <relationship name="states" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="State" inverseName="election" inverseEntity="State" syncable="YES"/>
+    </entity>
+    <entity name="ElectionAdministrationBody" representedClassName="ElectionAdministrationBody" syncable="YES">
+        <attribute name="absenteeVotingInfoURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="ballotInfoURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="electionInfoURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="electionRegistrationConfirmationURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="electionRegistrationURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="electionRulesURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <attribute name="hoursOfOperation" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="mailingAddress" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="physicalAddress" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="voterServices" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="votingLocationFinderURL" optional="YES" attributeType="String" maxValueString="2000" syncable="YES"/>
+        <relationship name="electionOfficials" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ElectionOfficial" inverseName="electionAdministrationBody" inverseEntity="ElectionOfficial" syncable="YES"/>
+        <relationship name="state" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="State" inverseName="electionAdministrationBody" inverseEntity="State" syncable="YES"/>
+    </entity>
+    <entity name="ElectionOfficial" representedClassName="ElectionOfficial" syncable="YES">
+        <attribute name="email" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="faxNumber" optional="YES" attributeType="String" maxValueString="16" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="officePhoneNumber" optional="YES" attributeType="String" maxValueString="16" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <relationship name="electionAdministrationBody" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ElectionAdministrationBody" inverseName="electionOfficials" inverseEntity="ElectionAdministrationBody" syncable="YES"/>
+    </entity>
+    <entity name="PollingLocation" representedClassName="PollingLocation" syncable="YES">
+        <attribute name="address" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <attribute name="addressLat" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="addressLon" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="isEarlyVoteSite" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="name" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="notes" optional="YES" attributeType="String" maxValueString="1024" syncable="YES"/>
+        <attribute name="pollingHours" optional="YES" attributeType="String" maxValueString="100" syncable="YES"/>
+        <attribute name="pollingLocationId" attributeType="String" maxValueString="32" syncable="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="voterServices" optional="YES" attributeType="String" maxValueString="255" syncable="YES"/>
+        <relationship name="dataSource" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DataSource" inverseName="pollingLocation" inverseEntity="DataSource" syncable="YES"/>
+        <relationship name="election" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Election" inverseName="pollingLocations" inverseEntity="Election" syncable="YES"/>
+    </entity>
+    <entity name="State" representedClassName="State" syncable="YES">
+        <attribute name="localJurisdiction" optional="YES" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="name" attributeType="String" maxValueString="64" syncable="YES"/>
+        <attribute name="stateId" attributeType="String" maxValueString="32" syncable="YES"/>
+        <relationship name="dataSource" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DataSource" inverseName="state" inverseEntity="DataSource" syncable="YES"/>
+        <relationship name="election" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Election" inverseName="states" inverseEntity="Election" syncable="YES"/>
+        <relationship name="electionAdministrationBody" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ElectionAdministrationBody" inverseName="state" inverseEntity="ElectionAdministrationBody" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Election" positionX="-63" positionY="-247" width="128" height="208"/>
+        <element name="PollingLocation" positionX="180" positionY="-184" width="128" height="238"/>
+        <element name="DataSource" positionX="-243" positionY="65" width="128" height="133"/>
+        <element name="Contest" positionX="207" positionY="98" width="128" height="298"/>
+        <element name="District" positionX="450" positionY="288" width="128" height="103"/>
+        <element name="Candidate" positionX="450" positionY="74" width="128" height="178"/>
+        <element name="State" positionX="277" positionY="-387" width="128" height="133"/>
+        <element name="ElectionAdministrationBody" positionX="459" positionY="-388" width="128" height="253"/>
+        <element name="ElectionOfficial" positionX="637" positionY="-385" width="128" height="133"/>
+    </elements>
 </model>


### PR DESCRIPTION
These models comprehensively cover the data returned in the VoterInfo query. 

You can look at field attributes either in the xml in the last file of this PR or by loading the branch up in xcode and clicking on the VotingInformationProject.xcdatamodeld file.
