### PR TITLE
Modify IS_WIDESCREEN to not use DBL_EPSILON

### DIFF
--- a/objc/VotingInformationProject/Podfile.lock
+++ b/objc/VotingInformationProject/Podfile.lock
@@ -23,7 +23,9 @@ PODS:
   - Kiwi/XCTest (2.2.3):
     - Kiwi/ARC
     - Kiwi/NonARC
-  - MagicalRecord (2.2)
+  - MagicalRecord (2.2):
+    - MagicalRecord/Core
+  - MagicalRecord/Core (2.2)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.0)
@@ -35,6 +37,6 @@ SPEC CHECKSUMS:
   AFNetworking: c7d7901a83f631414c7eda1737261f696101a5cd
   Google-Maps-iOS-SDK: ce1cffe3dca21af85c4bf9d9cb2778083d8fd6f5
   Kiwi: 04c51e880831d291748ec702d42c4101f7eb95c9
-  MagicalRecord: b1fc46c99a9749fe7fe7e6f43a89b62ef5201933
+  MagicalRecord: 95d49d74ef752cd52f6ad87bcb474817fc3978cf
 
 COCOAPODS: 0.29.0

--- a/objc/VotingInformationProject/VotingInformationProject/Models/ScreenMacros.h
+++ b/objc/VotingInformationProject/VotingInformationProject/Models/ScreenMacros.h
@@ -11,10 +11,10 @@
 #import <UIKit/UIDevice.h>
 #import <UIKit/UIScreen.h>
 
-// for DBL_EPSILON
-#import <float.h>
-
-#define IS_WIDESCREEN (fabs((double)[[UIScreen mainScreen] bounds].size.height - (double)568) < DBL_EPSILON)
+#define WIDESCREEN_HEIGHT 568
+// Quickfix because using the < DBL_EPSILON solution was failing the travis ci with DBL_EPSILON
+//  not found for some reason.
+#define IS_WIDESCREEN (fabs((double)[[UIScreen mainScreen] bounds].size.height > (double)WIDESCREEN_HEIGHT - 1))
 #define IS_IPHONE ([[[UIDevice currentDevice] model] isEqualToString:@"iPhone"])
 #define IS_IPOD   ([[[UIDevice currentDevice] model] isEqualToString:@"iPod touch"])
 


### PR DESCRIPTION
Could not reproduce DBL_EPSILON not found compiler error
locally (only on Travis CI).
Other fixes attempted:
- Use include for float.h
- Properly wrap all code in ifndefs
- Update arch settings in xcode proj
- Attempt to force travis to run iossimulator7.0/sdk7.0 and
  arch x64_86

Also updated Podfile, looks like MR was split into a core lib
  and some bonus dependencies. Run 'pod install' to update.
