### PR TITLE
Open directions action sheet from polling location list

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/NearbyPollingViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/NearbyPollingViewController.m
@@ -466,6 +466,7 @@ const NSUInteger VIP_POLLING_TABLECELL_HEIGHT = 76;
 
 -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (!self.cells.count) return;  // do not give directions on empty list item
     [self openDirectionsActionSheet:indexPath.row];
 }
 


### PR DESCRIPTION
Open prompt to get directions from list view of polling locations (in addition to getting the prompt when polling location marker popup tapped in map).
