### PR TITLE
Open Contest Details with a modal presentation

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/Base.lproj/VIPStoryBoard.storyboard
+++ b/objc/VotingInformationProject/VotingInformationProject/Base.lproj/VIPStoryBoard.storyboard
@@ -273,7 +273,7 @@
                                     </subviews>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <segue destination="7ZY-Ni-zvk" kind="push" identifier="ContestDetailsSegue" id="Jg4-NW-LJL"/>
+                                    <segue destination="fjh-JZ-oIn" kind="modal" identifier="ContestDetailsSegue" id="9kD-F5-7jl"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -302,7 +302,7 @@
                         <viewControllerLayoutGuide type="bottom" id="HIY-Da-tzn"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Fll-8I-Fhh">
-                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Contest Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yh4-mO-Jao">
@@ -318,7 +318,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="32" sectionFooterHeight="19" translatesAutoresizingMaskIntoConstraints="NO" id="vBo-6w-tqu">
-                                <rect key="frame" x="0.0" y="73" width="320" height="382"/>
+                                <rect key="frame" x="0.0" y="73" width="320" height="431"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
@@ -435,7 +435,13 @@
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Contest" id="02m-1K-uJy"/>
+                    <navigationItem key="navigationItem" title="Contest" id="02m-1K-uJy">
+                        <barButtonItem key="leftBarButtonItem" title="Ballot" id="xCZ-1X-Mny">
+                            <connections>
+                                <action selector="close:" destination="7ZY-Ni-zvk" id="Lz9-go-h2d"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="contestNameLabel" destination="Yh4-mO-Jao" id="7oF-yc-RrC"/>
                         <outlet property="electionNameLabel" destination="e5r-KA-iqC" id="vMn-WQ-oCJ"/>
@@ -444,7 +450,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="n81-Og-yRs" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2017" y="-606"/>
+            <point key="canvasLocation" x="2543" y="-606"/>
         </scene>
         <!--Candidate Details View Controller - Candidate-->
         <scene sceneID="8zN-tc-9rG">
@@ -455,7 +461,7 @@
                         <viewControllerLayoutGuide type="bottom" id="Xzj-DD-Xpr"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="aij-qL-i49">
-                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Candidate Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mZe-S3-Tn7">
@@ -475,7 +481,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="FpI-yk-lhW">
-                                <rect key="frame" x="0.0" y="73" width="320" height="382"/>
+                                <rect key="frame" x="0.0" y="73" width="320" height="431"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
@@ -603,7 +609,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MVG-M1-LB0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2480" y="-606"/>
+            <point key="canvasLocation" x="3006" y="-606"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="1xV-W7-NP6">
@@ -614,11 +620,11 @@
                         <viewControllerLayoutGuide type="bottom" id="caa-Tr-E9f"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="amI-3T-UiG">
-                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" scalesPageToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" id="POQ-8Z-IZQ">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="455"/>
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="504"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES" address="YES"/>
@@ -1041,6 +1047,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="z13-xd-9pl" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1496" y="946"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="pAJ-vL-Hlc">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="fjh-JZ-oIn" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" translucent="NO" prompted="NO"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="B5Q-Uf-jnS">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="7ZY-Ni-zvk" kind="relationship" relationship="rootViewController" id="aBF-gc-C2a"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pFY-O8-w51" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2017" y="-606"/>
         </scene>
     </scenes>
     <resources>

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotViewController.h
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotViewController.h
@@ -9,9 +9,10 @@
 
 #import "VIPTableViewController.h"
 #import "VIPTabBarController.h"
+#import "ContestDetailsViewController.h"
 #import "Election+API.h"
 
-@interface BallotViewController : VIPTableViewController
+@interface BallotViewController : VIPTableViewController <ContestDetailsViewControllerDelegate>
 
 @property (strong, nonatomic) Election *election;
 

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotViewController.m
@@ -91,6 +91,13 @@ const NSUInteger VIP_BALLOT_TABLECELL_HEIGHT = 44;
     // Dispose of any resources that can be recreated.
 }
 
+#pragma mark - ContestDetailsViewControllerDelegate
+
+- (void)contestDetailsViewControllerDidClose:(ContestDetailsViewController *)controller
+{
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -130,9 +137,11 @@ const NSUInteger VIP_BALLOT_TABLECELL_HEIGHT = 44;
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
     if ([segue.identifier isEqualToString:@"ContestDetailsSegue"]) {
-        ContestDetailsViewController *cdvc = (ContestDetailsViewController*) segue.destinationViewController;
+        UINavigationController *navController = (UINavigationController*) segue.destinationViewController;
+        ContestDetailsViewController *cdvc = (ContestDetailsViewController*) navController.viewControllers[0];
         UITableViewCell *cell = (UITableViewCell*)sender;
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
+        cdvc.delegate = self;
         cdvc.contest = _contests[indexPath.item];
         cdvc.electionName = self.election.electionName;
     }

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.h
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.h
@@ -10,6 +10,14 @@
 #import "VIPViewController.h"
 #import "Contest+API.h"
 
+@class ContestDetailsViewController;
+
+@protocol ContestDetailsViewControllerDelegate <NSObject>
+
+- (void)contestDetailsViewControllerDidClose:(ContestDetailsViewController*)controller;
+
+@end
+
 /**
  A Table View controller for displaying details about a Contest*
  Has two sections, first is key/value properties of the contest,
@@ -27,5 +35,7 @@ extern NSString * const REFERENDUM_API_ID;
  The election name associated with this contest
  */
 @property (strong, nonatomic) NSString* electionName;
+@property (weak, nonatomic) id<ContestDetailsViewControllerDelegate>delegate;
 
 @end
+

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.m
@@ -75,6 +75,10 @@ NSString * const REFERENDUM_API_ID = @"Referendum";
     [super didReceiveMemoryWarning];
 }
 
+- (IBAction)close:(id)sender {
+    [self.delegate contestDetailsViewControllerDidClose:self];
+}
+
 /**
  * Refresh data displayed in the elements on this view
  * Conditionally display Referendum elements if self.contest.type == REFERENDUM_API_ID


### PR DESCRIPTION
This has two major advantages:
- We properly use a separate navigation controller
  for the push segues within the contest details
  hierarchy
- We do not need to hide the tab bar when we push
  into contest details. This is generally an
  unsupported operation by apple:
  "Do not modify a tab bar that is managed by a tab bar controller (an
  instance of the UITabBarController class)"
