### PR TITLE
Fix #90: Sort contests by ballotPlacement

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotViewController.m
@@ -96,8 +96,9 @@ const NSUInteger VIP_BALLOT_TABLECELL_HEIGHT = 44;
     self.electionDateLabel.text = [self.election getDateString];
 
     NSArray *contests = [self.election getSorted:@"contests"
-                                      byProperty:@"office"
+                                      byProperty:@"ballotPlacement"
                                        ascending:YES];
+
     if ([self.party length] > 0) {
         NSString *predicateFormat = @"SELF.primaryParty = nil OR SELF.primaryParty CONTAINS[cd] %@";
         NSPredicate *partyFilterPredicate = [NSPredicate
@@ -192,7 +193,8 @@ const NSUInteger VIP_BALLOT_TABLECELL_HEIGHT = 44;
         ContestDetailsViewController *cdvc = (ContestDetailsViewController*) segue.destinationViewController;
         UITableViewCell *cell = (UITableViewCell*)sender;
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
-        cdvc.contest = _contests[indexPath.item];
+        Contest *contest = (Contest*)_contests[indexPath.item];
+        cdvc.contest = contest;
         cdvc.electionName = self.election.electionName;
     }
 }

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.m
@@ -100,7 +100,7 @@ NSString * const REFERENDUM_API_ID = @"Referendum";
                                                                               @"Contest details text displayed when office name not available");
         // Only add candidates for elections, not referenda
         [self.tableData addObject:[self.contest getSorted:@"candidates"
-                                               byProperty:@"name"
+                                               byProperty:@"orderOnBallot"
                                                 ascending:YES]];
     }
     [self.tableView reloadData];
@@ -288,7 +288,8 @@ NSString * const REFERENDUM_API_ID = @"Referendum";
 
         UITableViewCell *cell = (UITableViewCell*)sender;
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
-        cdvc.candidate = self.tableData[indexPath.section][indexPath.item];
+        Candidate *candidate = self.tableData[indexPath.section][indexPath.item];
+        cdvc.candidate = candidate;
 
     } else if ([segue.identifier isEqualToString:@"ContestUrlCellSegue"]) {
         UIWebViewController *webView = (UIWebViewController*) segue.destinationViewController;

--- a/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Contest+API.m
+++ b/objc/VotingInformationProject/VotingInformationProject/CoreDataModels/Contest+API.m
@@ -54,13 +54,11 @@
                               @"type": NSLocalizedString(@"Contest Type", @"Label in contest details section for contest type"),
                               @"primaryParty": NSLocalizedString(@"Primary Party", @"Label in contest details section for party in primary"),
                               @"district.name": NSLocalizedString(@"District Name", @"Label in contest details section for the district"),
-                              @"district.id": NSLocalizedString(@"District ID", @"Label in contest details section for the district ID"),
                               @"electorateSpecifications": NSLocalizedString(@"Electorate Specifications", @"Label in contest details section for electorate specifications"),
                               @"special": NSLocalizedString(@"Special", @"Label in contest details section for special"),
                               @"level": NSLocalizedString(@"Level", @"Label in contest details section for level"),
                               @"numberElected": NSLocalizedString(@"Number Elected", @"Label in contest details section for # elected"),
                               @"numberVotingFor": NSLocalizedString(@"Number Voting For", @"Label in contest details section for # voting for"),
-                              @"ballotPlacement": NSLocalizedString(@"Ballot Placement", @"Label in contest details section for ballot placement"),
                               @"referendumSubtitle": NSLocalizedString(@"Referendum Subtitle", @"Label in contest details section for referendum subtitle"),
                               @"referendumUrl": NSLocalizedString(@"Referendum URL", @"Label in contest details section for referendum URL link"),
                          };


### PR DESCRIPTION
Other related fixes:
- Remove district.id from contest details
- Remove ballotPlacement from contest details
- Sort candidates by orderOnBallot
