### PR TITLE
Make table headers opaque

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotDetailsViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/BallotDetailsViewController.m
@@ -158,7 +158,7 @@ const NSUInteger VIP_DETAILS_TABLECELL_HEIGHT = 44;
     label.textColor = primaryTextColor;
     label.text = NSLocalizedString(@"Election Administration Body", nil);
     [view addSubview:label];
-    [view setBackgroundColor:[VIPColor color:primaryTextColor withAlpha:0.5]];
+    [view setBackgroundColor:[VIPColor tableHeaderColor]];
     return view;
 }
 

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/CandidateDetailsViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/CandidateDetailsViewController.m
@@ -127,7 +127,7 @@ NSString * const CDVC_TABLE_CELLID_SOCIAL_EMPTY = @"CandidateSocialCellEmpty";
     label.textColor = primaryTextColor;
     label.text = [self titleForHeaderInSection:section];
     [view addSubview:label];
-    [view setBackgroundColor:[VIPColor color:primaryTextColor withAlpha:0.5]];
+    [view setBackgroundColor:[VIPColor tableHeaderColor]];
     return view;
 }
 

--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/ContestDetailsViewController.m
@@ -187,7 +187,7 @@ NSString * const REFERENDUM_API_ID = @"Referendum";
     label.textColor = primaryTextColor;
     label.text = [self titleForHeaderInSection:section];
     [view addSubview:label];
-    [view setBackgroundColor:[VIPColor color:primaryTextColor withAlpha:0.5]];
+    [view setBackgroundColor:[VIPColor tableHeaderColor]];
     return view;
 }
 

--- a/objc/VotingInformationProject/VotingInformationProject/Models/VIPColor.h
+++ b/objc/VotingInformationProject/VotingInformationProject/Models/VIPColor.h
@@ -25,6 +25,12 @@
          withAlpha:(CGFloat)alpha;
 
 /*
+ * key: tableHeaderColor
+ * value: A hex string, i.e. '#FFFFFF'
+ */
++ (UIColor*) tableHeaderColor;
+
+/*
  * key: navBarTextColor
  * value: A hex string, i.e. '#FFFFFF'
  */

--- a/objc/VotingInformationProject/VotingInformationProject/Models/VIPColor.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Models/VIPColor.m
@@ -54,6 +54,15 @@
     return [UIColor colorWithHexString:hexColor];
 }
 
++ (UIColor*)tableHeaderColor
+{
+    NSString *hexColor = [[AppSettings settings] valueForKey:@"tableHeaderColor"];
+    if (!hexColor) {
+        hexColor = @"0x8ea1b8";
+    }
+    return [UIColor colorWithHexString:hexColor];
+}
+
 + (UIColor*)navBarBackgroundColor
 {
     NSString *hexColor = [[AppSettings settings] valueForKey:@"navBarBackgroundColor"];
@@ -65,7 +74,7 @@
 
 + (UIColor*)navBarTextColor
 {
-    NSString *hexColor = [[AppSettings settings] valueForKey:@"navBarBackgroundColor"];
+    NSString *hexColor = [[AppSettings settings] valueForKey:@"navBarTextColor"];
     if (!hexColor) {
         return [self secondaryTextColor];
     }


### PR DESCRIPTION
@mtedeschi can weigh in on the selected opaque color

Before:
![ios simulator screen shot may 23 2014 8 45 59 am](https://cloud.githubusercontent.com/assets/1818302/3066663/a4ffc3e8-e278-11e3-951d-b438ebc87d59.png)
After:
![ios simulator screen shot may 23 2014 8 44 47 am](https://cloud.githubusercontent.com/assets/1818302/3066665/a71167b8-e278-11e3-9a0b-4ed9468f5621.png)
