### PR TITLE
Bugfix #117: Use telprompt url scheme on candidate call action

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/Models/CandidateLinkCell.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Models/CandidateLinkCell.m
@@ -53,7 +53,7 @@
     if (self.linkType == kCandidateLinkTypeWebsite) {
         _url = url;
     } else if (self.linkType == kCandidateLinkTypePhone) {
-        _url = [NSString stringWithFormat:@"tel:%@", url];
+        _url = [NSString stringWithFormat:@"telprompt:%@", url];
     } else if (self.linkType == kCandidateLinkTypeEmail) {
         _url = [NSString stringWithFormat:@"mailto:%@", url];
     } else {


### PR DESCRIPTION
The telprompt scheme does the following:
- Displays an AlertView asking the user to confirm the call
- Returns the user to the calling app after the phone call
  is completed

This telprompt url scheme is undocumented, but is used regularly
by other developers and there has never been a reported case of
Apple rejecting an app for its use. This url scheme is used
internally by UIWebView and MobileSafari.

If this url scheme is rejected or unsupported, we could easily
mimic its confirm functionality with an AlertView. The return user
to calling app functionality would be more difficult.
