### PR TITLE
Enable the use of test data in App v2.0.1

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/GoogleCivicAPI/CivicInfoAPI.m
+++ b/objc/VotingInformationProject/VotingInformationProject/GoogleCivicAPI/CivicInfoAPI.m
@@ -34,13 +34,17 @@
     NSString *apiKey = [settings objectForKey:@"GoogleCivicInfoAPIKey"];
 
     BOOL officialOnly = [[[AppSettings settings] objectForKey:@"OfficialOnly"] boolValue];
+    BOOL useTestData = [[[AppSettings settings] objectForKey:@"UseTestData"] boolValue];
     NSString *officialOnlyString = officialOnly ? @"True" : @"False";
     NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:@{
         @"address": address,
         @"key": apiKey,
         @"officialOnly": officialOnlyString
     }];
-    if (election && [election.id length] != 0) {
+    if (useTestData) {
+      [params setObject:@"2000" forKey:@"electionId"];
+    }
+    else if (election && [election.id length] != 0) {
         [params setObject:election.id forKey:@"electionId"];
     }
     if ([[AppSettings settings] valueForKey:@"DEBUG"]) {

--- a/objc/VotingInformationProject/VotingInformationProject/settings.plist.template
+++ b/objc/VotingInformationProject/VotingInformationProject/settings.plist.template
@@ -12,5 +12,7 @@
     <string>Your Brand Name Here</string>
 	<key>OfficialOnly</key>
 	<true/>
+    <key>UseTestData</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
I added a key to the settings.plist to enable test election data. It will override the current published election id if one is found.
