### PR TITLE
Closes #169: Disable map view and show message if no nearby locations

### DIFF
--- a/objc/VotingInformationProject/VotingInformationProject/Controllers/NearbyPollingViewController.m
+++ b/objc/VotingInformationProject/VotingInformationProject/Controllers/NearbyPollingViewController.m
@@ -127,6 +127,14 @@ const NSUInteger VIP_POLLING_TABLECELL_HEIGHT = 76;
         [newCells addObject:cell];
     }
     self.cells = newCells;
+
+    // If no cells, switch to list view and disable button
+    if ([newCells count] == 0) {
+        self.ourRightBarButtonItem.enabled = NO;
+        [self switchView:LIST_VIEW animated:NO];
+    } else {
+        self.ourRightBarButtonItem.enabled = YES;
+    }
 }
 
 - (id<UITableViewDataSource>)configureDataSource


### PR DESCRIPTION
As requested by @jen-tolentino, the app will now hide the map view and
disable the map switcher if the selected filter type has no locations.

If in the map view and a switch to a filter with no locations occurs,
the map view will hide and disable the button.
